### PR TITLE
Auto-start next timer block after completion

### DIFF
--- a/components/DashboardView.tsx
+++ b/components/DashboardView.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
-import type { Task, Settings, Session } from '../types';
+import type { Task, Settings, Session, TimerStatus } from '../types';
 import { TimerMode } from '../types';
 import Timer from './Timer';
 import BreakSuggestion from './BreakSuggestion';

--- a/components/Timer.tsx
+++ b/components/Timer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { TimerMode, Settings, TimerStatus } from '../types';
 import { TimerMode as TimerModeEnum, TimerStatus as TimerStatusEnum } from '../types';
 import { ICONS } from '../constants';
@@ -57,6 +57,14 @@ const CircularProgress: React.FC<{ progress: number; children: React.ReactNode }
 const Timer: React.FC<TimerProps> = ({ settings, onSessionComplete, timerMode, setTimerMode, pomodorosInSet, totalSeconds, setTotalSeconds, secondsLeft, setSecondsLeft, timerStatus, setTimerStatus }) => {
   const shouldAutoStart = useRef(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Automatically start the next session when the mode changes
+  useEffect(() => {
+    if (shouldAutoStart.current) {
+      setTimerStatus(TimerStatusEnum.RUNNING);
+      shouldAutoStart.current = false;
+    }
+  }, [timerMode, setTimerStatus]);
 
   // This useEffect now only handles the timer interval and completion logic
   useEffect(() => {


### PR DESCRIPTION
## Summary
- automatically kick off the next session when the timer mode changes
- remove manual timer stop from session completion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cbeef109c832fa67c327492da8c88