### PR TITLE
fix: center navigation bar on mobile

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -33,14 +33,14 @@ const NavButton: React.FC<{
 
 const Header: React.FC<HeaderProps> = ({ activeScreen, setActiveScreen }) => {
   return (
-    <header className="flex justify-between items-center bg-slate-900/50 backdrop-blur-sm p-3 rounded-xl border border-slate-700/50">
+    <header className="flex flex-col sm:flex-row sm:justify-between items-center bg-slate-900/50 backdrop-blur-sm p-3 rounded-xl border border-slate-700/50">
       <div className="flex items-center space-x-2">
          <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 text-cyan-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
          </svg>
         <h1 className="text-xl font-bold text-white">FocusFlow</h1>
       </div>
-      <nav className="flex items-center space-x-1 sm:space-x-2 bg-slate-800/70 p-1 rounded-lg">
+      <nav className="flex items-center space-x-1 sm:space-x-2 bg-slate-800/70 p-1 rounded-lg mt-2 sm:mt-0">
         <NavButton screen={ScreenEnum.DASHBOARD} activeScreen={activeScreen} onClick={setActiveScreen} icon={ICONS.TIMER} label="Timer" />
         <NavButton screen={ScreenEnum.TASKS} activeScreen={activeScreen} onClick={setActiveScreen} icon={ICONS.TASKS} label="Tasks" />
         <NavButton screen={ScreenEnum.STATS} activeScreen={activeScreen} onClick={setActiveScreen} icon={ICONS.STATS} label="Stats" />


### PR DESCRIPTION
## Summary
- ensure header stacks vertically on small screens so nav bar centered
- add top margin to nav for better spacing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cdb90aa5c832f856cccbf27400537