### PR TITLE
refactor: centralize timer duration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import type { Screen, Task, Session, Settings, TimerMode, TimerStatus } from './types';
 import { Screen as ScreenEnum, TimerMode as TimerModeEnum, TimerStatus as TimerStatusEnum } from './types';
 import { DEFAULT_SETTINGS } from './constants';
+import { getDuration } from './utils/time';
 import Header from './components/Header';
 import DashboardView from './components/DashboardView';
 import TasksView from './components/TasksView';
@@ -50,24 +51,16 @@ const App: React.FC = () => {
   const [timerMode, setTimerMode] = useState<TimerMode>(TimerModeEnum.WORK);
   const [pomodorosInSet, setPomodorosInSet] = useState(0);
   const shouldAutoStart = useRef(false);
-  const getDuration = useCallback((mode: TimerMode) => {
-    switch (mode) {
-      case TimerModeEnum.WORK: return settings.workDuration * 60;
-      case TimerModeEnum.SHORT_BREAK: return settings.shortBreakDuration * 60;
-      case TimerModeEnum.LONG_BREAK: return settings.longBreakDuration * 60;
-      default: return settings.workDuration * 60;
-    }
-  }, [settings]);
-  const [totalSeconds, setTotalSeconds] = useState(getDuration(timerMode));
-  const [secondsLeft, setSecondsLeft] = useState(getDuration(timerMode));
+  const [totalSeconds, setTotalSeconds] = useState(getDuration(timerMode, settings));
+  const [secondsLeft, setSecondsLeft] = useState(getDuration(timerMode, settings));
   const [timerStatus, setTimerStatus] = useState<TimerStatus>(TimerStatusEnum.STOPPED);
 
   useEffect(() => {
-    const newTotalSeconds = getDuration(timerMode);
+    const newTotalSeconds = getDuration(timerMode, settings);
     setTotalSeconds(newTotalSeconds);
     setSecondsLeft(newTotalSeconds);
     // Do not reset timerStatus here, it should be controlled by user actions
-  }, [timerMode, getDuration]);
+  }, [timerMode, settings]);
 
   useEffect(() => {
     if (shouldAutoStart.current) {

--- a/components/Timer.tsx
+++ b/components/Timer.tsx
@@ -3,6 +3,7 @@ import type { TimerMode, Settings, TimerStatus } from '../types';
 import { TimerMode as TimerModeEnum, TimerStatus as TimerStatusEnum } from '../types';
 import { ICONS } from '../constants';
 import InterruptionModal from './InterruptionModal';
+import { getDuration } from '../utils/time';
 
 interface TimerProps {
   settings: Settings;
@@ -63,15 +64,7 @@ const Timer: React.FC<TimerProps> = ({ settings, onSessionComplete, timerMode, s
   
   const resetTimer = () => {
     setTimerStatus(TimerStatusEnum.STOPPED);
-    // Recalculate totalSeconds based on current timerMode and settings
-    const newTotalSeconds = (() => {
-      switch (timerMode) {
-        case TimerModeEnum.WORK: return settings.workDuration * 60;
-        case TimerModeEnum.SHORT_BREAK: return settings.shortBreakDuration * 60;
-        case TimerModeEnum.LONG_BREAK: return settings.longBreakDuration * 60;
-        default: return settings.workDuration * 60;
-      }
-    })();
+    const newTotalSeconds = getDuration(timerMode, settings);
     setTotalSeconds(newTotalSeconds);
     setSecondsLeft(newTotalSeconds);
   };

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -1,0 +1,15 @@
+import type { TimerMode, Settings } from '../types';
+import { TimerMode as TimerModeEnum } from '../types';
+
+export function getDuration(mode: TimerMode, settings: Settings): number {
+  switch (mode) {
+    case TimerModeEnum.WORK:
+      return settings.workDuration * 60;
+    case TimerModeEnum.SHORT_BREAK:
+      return settings.shortBreakDuration * 60;
+    case TimerModeEnum.LONG_BREAK:
+      return settings.longBreakDuration * 60;
+    default:
+      return settings.workDuration * 60;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize timer duration logic in new `getDuration` helper
- replace duplicated switches in timer initialization and reset

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dd8440348832f9184d33767e155af