### PR TITLE
Abort ongoing break suggestion fetch on unmount

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -8,7 +8,9 @@ const fallback = [
 ];
 const pick = () => fallback[Math.floor(Math.random() * fallback.length)];
 
-export async function getBreakSuggestion(): Promise<string> {
+export async function getBreakSuggestion(
+  signal?: AbortSignal
+): Promise<string> {
   const prompt =
     "Sugiere una única micro-pausa saludable, concreta y sin pantallas. Devuelve solo la acción.";
 
@@ -17,6 +19,7 @@ export async function getBreakSuggestion(): Promise<string> {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt }),
+      signal,
     });
 
     if (!r.ok) {


### PR DESCRIPTION
## Summary
- Cancel in-flight break suggestion requests when component unmounts using `AbortController`
- Forward abort signal to `getBreakSuggestion` service to stop network fetches

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ddb7539e4832fa95ae276a057c99b