### PR TITLE
refactor: extract reusable TaskItem component

### DIFF
--- a/components/DashboardView.tsx
+++ b/components/DashboardView.tsx
@@ -1,9 +1,10 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import type { Task, Settings, TimerStatus } from '../types';
 import { TimerMode } from '../types';
 import Timer from './Timer';
 import BreakSuggestion from './BreakSuggestion';
+import TaskItem from './TaskItem';
 
 interface DashboardViewProps {
   tasks: Task[];
@@ -21,21 +22,6 @@ interface DashboardViewProps {
   setTimerStatus: (status: TimerStatus) => void;
   onSessionComplete: (duration: number, isCompleted: boolean) => void;
 }
-
-const TaskItem: React.FC<{ task: Task; isActive: boolean; onClick: (id: string) => void }> = ({ task, isActive, onClick }) => (
-  <div
-    onClick={() => onClick(task.id)}
-    className={`p-3 rounded-lg cursor-pointer transition-all duration-200 border-l-4 ${isActive ? 'bg-slate-700/80 border-cyan-400' : 'bg-slate-800 hover:bg-slate-700/50 border-slate-600'}`}
-  >
-    <p className="font-medium text-white">{task.title}</p>
-    <div className="flex items-center text-sm text-slate-400 mt-1">
-      <span>{task.pomodorosCompleted} / {task.pomodoros}</span>
-      <div className="w-full bg-slate-600 rounded-full h-1.5 ml-2">
-        <div className="bg-cyan-500 h-1.5 rounded-full" style={{ width: `${(task.pomodorosCompleted / task.pomodoros) * 100}%` }}></div>
-      </div>
-    </div>
-  </div>
-);
 
 const DashboardView: React.FC<DashboardViewProps> = ({ tasks, settings, activeTaskId, setActiveTaskId, timerMode, setTimerMode, pomodorosInSet, totalSeconds, setTotalSeconds, secondsLeft, setSecondsLeft, timerStatus, setTimerStatus, onSessionComplete }) => {
 
@@ -87,9 +73,14 @@ const DashboardView: React.FC<DashboardViewProps> = ({ tasks, settings, activeTa
               todayTasks.map(task => (
                 <TaskItem
                   key={task.id}
-                  task={task}
-                  isActive={task.id === activeTaskId}
-                  onClick={setActiveTaskId}
+                  title={task.title}
+                  progress={{ current: task.pomodorosCompleted, total: task.pomodoros }}
+                  onClick={() => setActiveTaskId(task.id)}
+                  className={`transition-all duration-200 border-l-4 ${
+                    task.id === activeTaskId
+                      ? 'bg-slate-700/80 border-cyan-400'
+                      : 'bg-slate-800 hover:bg-slate-700/50 border-slate-600'
+                  }`}
                 />
               ))
             ) : (

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+interface TaskItemProps {
+  title: string;
+  progress?: {
+    current: number;
+    total: number;
+  };
+  actions?: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+}
+
+const TaskItem: React.FC<TaskItemProps> = ({ title, progress, actions, onClick, className = '' }) => {
+  const percentage = progress && progress.total > 0 ? (progress.current / progress.total) * 100 : 0;
+
+  return (
+    <div
+      onClick={onClick}
+      className={`flex items-center justify-between p-3 rounded-lg ${onClick ? 'cursor-pointer' : ''} ${className}`}
+    >
+      <div className="flex-1">
+        <p className="font-medium text-white">{title}</p>
+        {progress && (
+          <div className="flex items-center text-sm text-slate-400 mt-1">
+            <span>{progress.current} / {progress.total}</span>
+            <div className="w-full bg-slate-600 rounded-full h-1.5 ml-2">
+              <div className="bg-cyan-500 h-1.5 rounded-full" style={{ width: `${percentage}%` }}></div>
+            </div>
+          </div>
+        )}
+      </div>
+      {actions && (
+        <div className="flex items-center space-x-2 ml-4">
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TaskItem;

--- a/components/TasksView.tsx
+++ b/components/TasksView.tsx
@@ -2,93 +2,19 @@
 import React, { useState } from 'react';
 import type { Task } from '../types';
 import { ICONS } from '../constants';
+import TaskItem from './TaskItem';
 
 interface TasksViewProps {
   tasks: Task[];
   setTasks: React.Dispatch<React.SetStateAction<Task[]>>;
 }
 
-const TaskItem: React.FC<{
-  task: Task;
-  onToggleToday: (id: string) => void;
-  onDelete: (id: string) => void;
-  onEdit: (id: string, title: string, pomodoros: number) => void;
-}> = ({ task, onToggleToday, onDelete, onEdit }) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [editTitle, setEditTitle] = useState(task.title);
-  const [editPomos, setEditPomos] = useState(task.pomodoros);
-
-  const handleSave = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (editTitle.trim()) {
-      onEdit(task.id, editTitle.trim(), editPomos);
-      setIsEditing(false);
-    }
-  };
-
-  const handleCancel = () => {
-    setIsEditing(false);
-    setEditTitle(task.title);
-    setEditPomos(task.pomodoros);
-  };
-
-  return (
-    <div className="flex items-center justify-between p-3 bg-slate-800 rounded-lg">
-      {isEditing ? (
-        <form onSubmit={handleSave} className="flex flex-col space-y-2 w-full">
-          <input
-            type="text"
-            value={editTitle}
-            onChange={(e) => setEditTitle(e.target.value)}
-            className="w-full bg-slate-700 text-white p-2 rounded-lg border border-slate-600 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-          />
-          <div className="flex items-center space-x-2">
-            <input
-              type="number"
-              value={editPomos}
-              min={1}
-              onChange={(e) => setEditPomos(Math.max(1, parseInt(e.target.value, 10)))}
-              className="w-20 bg-slate-700 text-white p-2 rounded-lg border border-slate-600 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-            />
-            <div className="ml-auto space-x-2">
-              <button type="submit" className="px-3 py-1 text-sm rounded-full bg-cyan-500 text-slate-900 font-semibold">
-                Save
-              </button>
-              <button type="button" onClick={handleCancel} className="px-3 py-1 text-sm rounded-full bg-slate-700 hover:bg-slate-600 text-slate-300">
-                Cancel
-              </button>
-            </div>
-          </div>
-        </form>
-      ) : (
-        <>
-          <div>
-            <p className="font-medium text-white">{task.title}</p>
-            <p className="text-sm text-slate-400">Est. Pomodoros: {task.pomodoros}</p>
-          </div>
-          <div className="flex items-center space-x-2">
-            <button
-              onClick={() => onToggleToday(task.id)}
-              className={`px-3 py-1 text-sm rounded-full transition-colors ${task.isToday ? 'bg-cyan-500 text-slate-900 font-semibold' : 'bg-slate-700 hover:bg-slate-600 text-slate-300'}`}
-            >
-              {task.isToday ? 'Today' : 'Add to Today'}
-            </button>
-            <button onClick={() => setIsEditing(true)} className="p-2 text-slate-400 hover:text-cyan-400 hover:bg-cyan-500/10 rounded-full transition-colors">
-              {ICONS.EDIT}
-            </button>
-            <button onClick={() => onDelete(task.id)} className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-full transition-colors">
-              {ICONS.TRASH}
-            </button>
-          </div>
-        </>
-      )}
-    </div>
-  );
-};
-
 const TasksView: React.FC<TasksViewProps> = ({ tasks, setTasks }) => {
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [newTaskPomos, setNewTaskPomos] = useState(1);
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editPomos, setEditPomos] = useState(1);
 
   const handleAddTask = (e: React.FormEvent) => {
     e.preventDefault();
@@ -121,6 +47,24 @@ const TasksView: React.FC<TasksViewProps> = ({ tasks, setTasks }) => {
         ? { ...t, title, pomodoros, completed: t.pomodorosCompleted >= pomodoros }
         : t
     ));
+  };
+
+  const startEditing = (task: Task) => {
+    setEditingTaskId(task.id);
+    setEditTitle(task.title);
+    setEditPomos(task.pomodoros);
+  };
+
+  const handleSaveEdit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editingTaskId && editTitle.trim()) {
+      handleEditTask(editingTaskId, editTitle.trim(), editPomos);
+      setEditingTaskId(null);
+    }
+  };
+
+  const handleCancelEdit = () => {
+    setEditingTaskId(null);
   };
   
   const todayTasks = tasks.filter(t => t.isToday && !t.completed);
@@ -162,20 +106,118 @@ const TasksView: React.FC<TasksViewProps> = ({ tasks, setTasks }) => {
         <div className="p-6 bg-slate-800/50 rounded-2xl border border-slate-700/50">
             <h2 className="text-xl font-bold text-white mb-4">To-Do Today</h2>
             <div className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                {todayTasks.length > 0 ? todayTasks.map(task => (
-                    <TaskItem key={task.id} task={task} onToggleToday={handleToggleToday} onDelete={handleDeleteTask} onEdit={handleEditTask} />
-                )) : <p className="text-slate-400">No tasks for today.</p>}
-            </div>
-        </div>
+                  {todayTasks.length > 0 ? todayTasks.map(task => (
+                    editingTaskId === task.id ? (
+                      <form key={task.id} onSubmit={handleSaveEdit} className="flex flex-col space-y-2 p-3 bg-slate-800 rounded-lg">
+                        <input
+                          type="text"
+                          value={editTitle}
+                          onChange={(e) => setEditTitle(e.target.value)}
+                          className="w-full bg-slate-700 text-white p-2 rounded-lg border border-slate-600 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                        />
+                        <div className="flex items-center space-x-2">
+                          <input
+                            type="number"
+                            value={editPomos}
+                            min={1}
+                            onChange={(e) => setEditPomos(Math.max(1, parseInt(e.target.value, 10)))}
+                            className="w-20 bg-slate-700 text-white p-2 rounded-lg border border-slate-600 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                          />
+                          <div className="ml-auto space-x-2">
+                            <button type="submit" className="px-3 py-1 text-sm rounded-full bg-cyan-500 text-slate-900 font-semibold">
+                              Save
+                            </button>
+                            <button type="button" onClick={handleCancelEdit} className="px-3 py-1 text-sm rounded-full bg-slate-700 hover:bg-slate-600 text-slate-300">
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      </form>
+                    ) : (
+                      <TaskItem
+                        key={task.id}
+                        title={task.title}
+                        progress={{ current: task.pomodorosCompleted, total: task.pomodoros }}
+                        actions={
+                          <>
+                            <button
+                              onClick={() => handleToggleToday(task.id)}
+                              className={`px-3 py-1 text-sm rounded-full transition-colors ${task.isToday ? 'bg-cyan-500 text-slate-900 font-semibold' : 'bg-slate-700 hover:bg-slate-600 text-slate-300'}`}
+                            >
+                              {task.isToday ? 'Today' : 'Add to Today'}
+                            </button>
+                            <button onClick={() => startEditing(task)} className="p-2 text-slate-400 hover:text-cyan-400 hover:bg-cyan-500/10 rounded-full transition-colors">
+                              {ICONS.EDIT}
+                            </button>
+                            <button onClick={() => handleDeleteTask(task.id)} className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-full transition-colors">
+                              {ICONS.TRASH}
+                            </button>
+                          </>
+                        }
+                        className="bg-slate-800"
+                      />
+                    )
+                  )) : <p className="text-slate-400">No tasks for today.</p>}
+              </div>
+          </div>
 
         <div className="p-6 bg-slate-800/50 rounded-2xl border border-slate-700/50">
             <h2 className="text-xl font-bold text-white mb-4">Activity Inventory</h2>
             <div className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                {inventoryTasks.length > 0 ? inventoryTasks.map(task => (
-                    <TaskItem key={task.id} task={task} onToggleToday={handleToggleToday} onDelete={handleDeleteTask} onEdit={handleEditTask} />
-                )) : <p className="text-slate-400">Inventory is empty. Add a task!</p>}
-            </div>
-        </div>
+                  {inventoryTasks.length > 0 ? inventoryTasks.map(task => (
+                    editingTaskId === task.id ? (
+                      <form key={task.id} onSubmit={handleSaveEdit} className="flex flex-col space-y-2 p-3 bg-slate-800 rounded-lg">
+                        <input
+                          type="text"
+                          value={editTitle}
+                          onChange={(e) => setEditTitle(e.target.value)}
+                          className="w-full bg-slate-700 text-white p-2 rounded-lg border border-slate-600 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                        />
+                        <div className="flex items-center space-x-2">
+                          <input
+                            type="number"
+                            value={editPomos}
+                            min={1}
+                            onChange={(e) => setEditPomos(Math.max(1, parseInt(e.target.value, 10)))}
+                            className="w-20 bg-slate-700 text-white p-2 rounded-lg border border-slate-600 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                          />
+                          <div className="ml-auto space-x-2">
+                            <button type="submit" className="px-3 py-1 text-sm rounded-full bg-cyan-500 text-slate-900 font-semibold">
+                              Save
+                            </button>
+                            <button type="button" onClick={handleCancelEdit} className="px-3 py-1 text-sm rounded-full bg-slate-700 hover:bg-slate-600 text-slate-300">
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      </form>
+                    ) : (
+                      <TaskItem
+                        key={task.id}
+                        title={task.title}
+                        progress={{ current: task.pomodorosCompleted, total: task.pomodoros }}
+                        actions={
+                          <>
+                            <button
+                              onClick={() => handleToggleToday(task.id)}
+                              className={`px-3 py-1 text-sm rounded-full transition-colors ${task.isToday ? 'bg-cyan-500 text-slate-900 font-semibold' : 'bg-slate-700 hover:bg-slate-600 text-slate-300'}`}
+                            >
+                              {task.isToday ? 'Today' : 'Add to Today'}
+                            </button>
+                            <button onClick={() => startEditing(task)} className="p-2 text-slate-400 hover:text-cyan-400 hover:bg-cyan-500/10 rounded-full transition-colors">
+                              {ICONS.EDIT}
+                            </button>
+                            <button onClick={() => handleDeleteTask(task.id)} className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-full transition-colors">
+                              {ICONS.TRASH}
+                            </button>
+                          </>
+                        }
+                        className="bg-slate-800"
+                      />
+                    )
+                  )) : <p className="text-slate-400">Inventory is empty. Add a task!</p>}
+              </div>
+          </div>
          <div className="p-6 bg-slate-800/50 rounded-2xl border border-slate-700/50 opacity-60">
             <h2 className="text-xl font-bold text-white mb-4">Completed</h2>
             <div className="space-y-3 max-h-40 overflow-y-auto pr-2">


### PR DESCRIPTION
## Summary
- create shared `TaskItem` component for displaying titles, progress and custom actions
- swap inline task item implementations in `DashboardView` and `TasksView` with new component

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de5dae9d8832fbbb93e58c6be2c12