### PR TITLE
chore: drop API_KEY define

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- remove unused API_KEY define from Vite configuration

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found due to missing dev dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689df5afdad0832f8233172ebd94aa5d