### PR TITLE
Add privacy policy link to settings

### DIFF
--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -97,6 +97,14 @@ const SettingsView: React.FC<SettingsViewProps> = ({ settings, setSettings }) =>
         >
             Reset to Defaults
         </button>
+        <a
+          href="/privacy.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block text-center text-slate-400 hover:text-white underline mt-2"
+        >
+          Privacy Policy
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- link the Privacy Policy from the Settings view

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee84ceab0832f89550444f014bb34