### PR TITLE
Add Vitest configuration for excluding build directories

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    exclude: ['node_modules', 'dist', '.vercel', '.next', 'build']
+  }
+});


### PR DESCRIPTION
## Summary
- add `vitest.config.ts` to explicitly exclude build and framework directories

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1f4ae90832f8dc8eff2542f40a3