### PR TITLE
feat: mark tasks complete mid-pomodoro

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -126,6 +126,14 @@ const App: React.FC = () => {
       }));
   }, []);
 
+  const completeTask = useCallback((taskId: string) => {
+      setTasks(prevTasks => prevTasks.map(t =>
+          t.id === taskId
+              ? { ...t, pomodorosCompleted: t.pomodoros, completed: true }
+              : t
+      ));
+  }, []);
+
   const playSoundWithFallback = (primary: string, fallback: string) => {
     const audio = new Audio(primary);
     audio.play().catch(error => {
@@ -216,15 +224,16 @@ const App: React.FC = () => {
             pomodorosInSet={pomodorosInSet}
             totalSeconds={totalSeconds}
             setTotalSeconds={setTotalSeconds}
-            secondsLeft={secondsLeft}
-            setSecondsLeft={setSecondsLeft}
-            timerStatus={timerStatus}
-            setTimerStatus={setTimerStatus}
-            onSessionComplete={handleSessionComplete}
-          />
-        );
-    }
-  };
+              secondsLeft={secondsLeft}
+              setSecondsLeft={setSecondsLeft}
+              timerStatus={timerStatus}
+              setTimerStatus={setTimerStatus}
+              onSessionComplete={handleSessionComplete}
+              onCompleteTask={completeTask}
+            />
+          );
+      }
+    };
 
   return (
     <div className="bg-slate-900 text-white min-h-screen flex flex-col items-center">

--- a/components/DashboardView.tsx
+++ b/components/DashboardView.tsx
@@ -1,10 +1,11 @@
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Task, Settings, TimerStatus } from '../types';
 import { TimerMode } from '../types';
 import Timer from './Timer';
 import BreakSuggestion from './BreakSuggestion';
 import TaskItem from './TaskItem';
+import NextTaskModal from './NextTaskModal';
 
 interface DashboardViewProps {
   tasks: Task[];
@@ -21,12 +22,27 @@ interface DashboardViewProps {
   timerStatus: TimerStatus;
   setTimerStatus: (status: TimerStatus) => void;
   onSessionComplete: (duration: number, isCompleted: boolean) => void;
+  onCompleteTask: (taskId: string) => void;
 }
 
-const DashboardView: React.FC<DashboardViewProps> = ({ tasks, settings, activeTaskId, setActiveTaskId, timerMode, setTimerMode, pomodorosInSet, totalSeconds, setTotalSeconds, secondsLeft, setSecondsLeft, timerStatus, setTimerStatus, onSessionComplete }) => {
+const DashboardView: React.FC<DashboardViewProps> = ({ tasks, settings, activeTaskId, setActiveTaskId, timerMode, setTimerMode, pomodorosInSet, totalSeconds, setTotalSeconds, secondsLeft, setSecondsLeft, timerStatus, setTimerStatus, onSessionComplete, onCompleteTask }) => {
 
   const activeTask = tasks.find(t => t.id === activeTaskId);
   const todayTasks = tasks.filter(t => t.isToday && !t.completed);
+  const [showTaskSelector, setShowTaskSelector] = useState(false);
+
+  const handleCompleteTask = () => {
+    if (activeTaskId) {
+      onCompleteTask(activeTaskId);
+      setActiveTaskId(null);
+      setShowTaskSelector(true);
+    }
+  };
+
+  const handleSelectNextTask = (id: string) => {
+    setActiveTaskId(id);
+    setShowTaskSelector(false);
+  };
 
   useEffect(() => {
     if (!activeTaskId && todayTasks.length > 0) {
@@ -57,15 +73,23 @@ const DashboardView: React.FC<DashboardViewProps> = ({ tasks, settings, activeTa
           <h2 className="text-lg font-bold text-white mb-3">
             {activeTask ? 'Current Task' : 'No Active Task'}
           </h2>
-          {activeTask ? (
-             <div className="p-4 rounded-lg bg-slate-700 border-l-4 border-cyan-400">
-                <p className="font-bold text-xl text-white">{activeTask.title}</p>
-                <p className="text-slate-300 mt-1">Estimated Pomodoros: {activeTask.pomodoros}</p>
-             </div>
-          ) : (
-             <p className="text-slate-400">Select a task from your 'To-Do Today' list to begin.</p>
-          )}
-        </div>
+            {activeTask ? (
+              <>
+                <div className="p-4 rounded-lg bg-slate-700 border-l-4 border-cyan-400">
+                  <p className="font-bold text-xl text-white">{activeTask.title}</p>
+                  <p className="text-slate-300 mt-1">Estimated Pomodoros: {activeTask.pomodoros}</p>
+                </div>
+                <button
+                  onClick={handleCompleteTask}
+                  className="mt-3 w-full flex justify-center items-center space-x-2 bg-green-500 text-slate-900 font-bold p-2 rounded-lg hover:bg-green-400 transition-colors"
+                >
+                  Mark as Done
+                </button>
+              </>
+            ) : (
+               <p className="text-slate-400">Select a task from your 'To-Do Today' list to begin.</p>
+            )}
+          </div>
         <div className="p-4 bg-slate-800/50 rounded-2xl border border-slate-700/50 flex-grow">
           <h2 className="text-lg font-bold text-white mb-3">To-Do Today</h2>
           <div className="space-y-3 max-h-96 overflow-y-auto pr-2">
@@ -89,6 +113,12 @@ const DashboardView: React.FC<DashboardViewProps> = ({ tasks, settings, activeTa
           </div>
         </div>
       </div>
+      <NextTaskModal
+        isOpen={showTaskSelector}
+        tasks={todayTasks}
+        onSelect={handleSelectNextTask}
+        onClose={() => setShowTaskSelector(false)}
+      />
     </div>
   );
 };

--- a/components/NextTaskModal.tsx
+++ b/components/NextTaskModal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import type { Task } from '../types';
+
+interface NextTaskModalProps {
+  isOpen: boolean;
+  tasks: Task[];
+  onSelect: (taskId: string) => void;
+  onClose: () => void;
+}
+
+const NextTaskModal: React.FC<NextTaskModalProps> = ({ isOpen, tasks, onSelect, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex justify-center items-center z-50" onClick={onClose}>
+      <div className="bg-slate-800 rounded-xl p-6 border border-slate-700 w-full max-w-sm" onClick={e => e.stopPropagation()}>
+        <h2 className="text-xl font-bold text-white mb-4">Select Next Task</h2>
+        <div className="space-y-2 max-h-60 overflow-y-auto">
+          {tasks.length > 0 ? (
+            tasks.map(task => (
+              <button
+                key={task.id}
+                onClick={() => onSelect(task.id)}
+                className="w-full text-left px-4 py-2 bg-slate-700 hover:bg-slate-600 rounded-lg text-slate-200"
+              >
+                {task.title}
+              </button>
+            ))
+          ) : (
+            <p className="text-slate-400">No tasks available.</p>
+          )}
+        </div>
+        <div className="flex justify-end mt-4">
+          <button onClick={onClose} className="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-300">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NextTaskModal;


### PR DESCRIPTION
## Summary
- allow finishing the current task during a Pomodoro
- choose the next task to focus on via modal

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef25967f4832f956aeb77765de198